### PR TITLE
🎯 强制使用 GraphQL 并修复端点配置

### DIFF
--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -1,6 +1,6 @@
-import React, { createContext, useContext, useReducer, useCallback } from 'react';
+import { createContext, useContext, useReducer, useCallback } from 'react';
 import { Message, AppConfig, ConnectionStatus } from '../types';
-import { sendChatMessage, testGraphQLConnection, getHealthStatus } from '../services/graphqlClient';
+import { sendChatMessage, sendChatMessageRest, testGraphQLConnection, getHealthStatus } from '../services/graphqlClient';
 
 interface ChatState {
   messages: Message[];
@@ -23,7 +23,7 @@ const initialState: ChatState = {
   loading: false,
   config: {
     useMarkdown: true,
-    useGraphQL: true,
+    useGraphQL: true, // 默认强制使用GraphQL
     maxRetries: 3,
     retryDelay: 1000,
   },
@@ -97,6 +97,11 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
     dispatch({ type: 'SET_LOADING', payload: true });
     dispatch({ type: 'SET_ERROR', payload: '' });
 
+    console.log('🚀 开始发送消息，当前配置:', {
+      useGraphQL: state.config.useGraphQL,
+      messageCount: state.messages.length + 1
+    });
+
     try {
       const messages = [...state.messages, userMessage];
       const graphqlMessages = messages.map(msg => ({
@@ -105,41 +110,41 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
       }));
 
       let responseContent: string;
+      let usedGraphQL = false;
 
+      // 优先尝试 GraphQL
       if (state.config.useGraphQL) {
         try {
+          console.log('📡 尝试使用GraphQL发送消息...');
           const response = await sendChatMessage(graphqlMessages);
           responseContent = response.choices?.[0]?.message?.content || '抱歉，我无法回答这个问题。';
+          usedGraphQL = true;
+          console.log('✅ GraphQL消息发送成功');
         } catch (error) {
-          console.warn('GraphQL失败，切换到REST:', error);
-          dispatch({ type: 'UPDATE_CONFIG', payload: { useGraphQL: false } });
+          console.warn('⚠️ GraphQL失败，尝试REST备用方案:', error);
           
-          const restResponse = await fetch('/api/chat', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ messages: graphqlMessages }),
-          });
-          
-          if (!restResponse.ok) {
-            throw new Error(`REST API错误: ${restResponse.status}`);
+          try {
+            const restResponse = await sendChatMessageRest(graphqlMessages);
+            responseContent = restResponse.choices?.[0]?.message?.content || '抱歉，我无法回答这个问题。';
+            console.log('✅ REST备用方案成功');
+            
+            // 暂时禁用GraphQL，但不永久切换
+            console.log('⚠️ 本次使用REST，下次仍会尝试GraphQL');
+          } catch (restError) {
+            console.error('❌ REST备用方案也失败:', restError);
+            throw new Error(`GraphQL和REST都失败: ${error instanceof Error ? error.message : '未知错误'}`);
           }
-          
-          const restData = await restResponse.json();
-          responseContent = restData.choices?.[0]?.message?.content || '抱歉，我无法回答这个问题。';
         }
       } else {
-        const response = await fetch('/api/chat', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ messages: graphqlMessages }),
-        });
-
-        if (!response.ok) {
-          throw new Error(`REST API错误: ${response.status}`);
+        console.log('📡 使用REST API发送消息...');
+        try {
+          const restResponse = await sendChatMessageRest(graphqlMessages);
+          responseContent = restResponse.choices?.[0]?.message?.content || '抱歉，我无法回答这个问题。';
+          console.log('✅ REST API消息发送成功');
+        } catch (restError) {
+          console.error('❌ REST API失败:', restError);
+          throw restError;
         }
-
-        const data = await response.json();
-        responseContent = data.choices?.[0]?.message?.content || '抱歉，我无法回答这个问题。';
       }
 
       const assistantMessage: Message = {
@@ -150,8 +155,14 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
       };
 
       dispatch({ type: 'ADD_MESSAGE', payload: assistantMessage });
+      
+      console.log('🎉 消息发送完成', {
+        usedGraphQL,
+        responseLength: responseContent.length
+      });
+
     } catch (error) {
-      console.error('发送消息错误:', error);
+      console.error('💥 发送消息失败:', error);
       const errorMessage = error instanceof Error ? error.message : '未知错误';
       dispatch({ type: 'SET_ERROR', payload: errorMessage });
 
@@ -169,15 +180,23 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
   }, [state.messages, state.loading, state.config.useGraphQL]);
 
   const clearChat = useCallback(() => {
+    console.log('🗑️ 清空聊天记录');
     dispatch({ type: 'CLEAR_MESSAGES' });
   }, []);
 
   const checkConnection = useCallback(async () => {
+    console.log('🔍 开始检查连接状态...');
+    
     try {
       const [healthOk, graphqlOk] = await Promise.all([
         getHealthStatus(),
         testGraphQLConnection(),
       ]);
+
+      console.log('🏥 连接检查结果:', {
+        health: healthOk ? '✅' : '❌',
+        graphql: graphqlOk ? '✅' : '❌'
+      });
 
       const status: ConnectionStatus = {
         status: healthOk && graphqlOk ? 'connected' : 'failed',
@@ -188,6 +207,8 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
 
       dispatch({ type: 'SET_CONNECTION_STATUS', payload: status });
     } catch (error) {
+      console.error('❌ 连接检查异常:', error);
+      
       const status: ConnectionStatus = {
         status: 'failed',
         endpoint: '',
@@ -217,3 +238,9 @@ export function useChat() {
   }
   return context;
 }
+
+// 导出调试信息
+console.log('🎯 useChat Hook已加载，默认配置:');
+console.log('  - useGraphQL: true (强制优先使用)');
+console.log('  - useMarkdown: true');
+console.log('  - maxRetries: 3');

--- a/src/services/graphqlClient.ts
+++ b/src/services/graphqlClient.ts
@@ -28,10 +28,10 @@ const CHAT_MUTATION = `
   }
 `;
 
-// 改进的环境检测函数
+// 获取完整的API端点
 function getApiUrl(): string {
   if (typeof window === 'undefined') {
-    return 'https://bestvip.life/api/graphql'; // SSR fallback
+    return 'https://ai-chat-api.593496637.workers.dev/api/graphql'; // SSR fallback
   }
   
   const host = window.location.hostname;
@@ -51,19 +51,80 @@ function getApiUrl(): string {
     return 'http://localhost:8787/api/graphql'; // Wrangler默认端口
   }
   
-  // 默认回退到生产环境
+  // 默认回退到Worker端点
   return 'https://ai-chat-api.593496637.workers.dev/api/graphql';
+}
+
+// 获取健康检查端点
+function getHealthUrl(): string {
+  if (typeof window === 'undefined') {
+    return 'https://ai-chat-api.593496637.workers.dev/api/health'; // SSR fallback
+  }
+  
+  const host = window.location.hostname;
+  
+  // 生产环境
+  if (host === 'bestvip.life') {
+    return 'https://bestvip.life/api/health';
+  }
+  
+  // Cloudflare Pages预览环境
+  if (host.includes('pages.dev')) {
+    return 'https://ai-chat-api.593496637.workers.dev/api/health';
+  }
+  
+  // 本地开发环境
+  if (host === 'localhost' || host === '127.0.0.1') {
+    return 'http://localhost:8787/api/health'; // Wrangler默认端口
+  }
+  
+  // 默认回退到Worker端点
+  return 'https://ai-chat-api.593496637.workers.dev/api/health';
+}
+
+// 获取REST API端点（作为GraphQL的备份）
+function getRestUrl(): string {
+  if (typeof window === 'undefined') {
+    return 'https://ai-chat-api.593496637.workers.dev/api/chat'; // SSR fallback
+  }
+  
+  const host = window.location.hostname;
+  
+  // 生产环境
+  if (host === 'bestvip.life') {
+    return 'https://bestvip.life/api/chat';
+  }
+  
+  // Cloudflare Pages预览环境
+  if (host.includes('pages.dev')) {
+    return 'https://ai-chat-api.593496637.workers.dev/api/chat';
+  }
+  
+  // 本地开发环境
+  if (host === 'localhost' || host === '127.0.0.1') {
+    return 'http://localhost:8787/api/chat'; // Wrangler默认端口
+  }
+  
+  // 默认回退到Worker端点
+  return 'https://ai-chat-api.593496637.workers.dev/api/chat';
 }
 
 // 改进的GraphQL客户端，增加错误处理和重试机制
 export class GraphQLClient {
   private endpoint: string;
+  private healthEndpoint: string;
+  private restEndpoint: string;
   private maxRetries = 3;
   private retryDelay = 1000;
 
   constructor() {
     this.endpoint = getApiUrl();
-    console.log('GraphQL客户端初始化，端点:', this.endpoint);
+    this.healthEndpoint = getHealthUrl();
+    this.restEndpoint = getRestUrl();
+    console.log('🚀 GraphQL客户端初始化:');
+    console.log('  - GraphQL端点:', this.endpoint);
+    console.log('  - 健康检查端点:', this.healthEndpoint);
+    console.log('  - REST备用端点:', this.restEndpoint);
   }
 
   // 私有方法：延迟函数
@@ -73,7 +134,11 @@ export class GraphQLClient {
 
   // 私有方法：执行HTTP请求
   private async executeRequest(query: string, variables?: any): Promise<any> {
-    console.log('发送GraphQL请求:', { query: query.trim(), variables, endpoint: this.endpoint });
+    console.log('📤 发送GraphQL请求:', { 
+      query: query.trim(), 
+      variables, 
+      endpoint: this.endpoint 
+    });
     
     const response = await fetch(this.endpoint, {
       method: 'POST',
@@ -84,19 +149,19 @@ export class GraphQLClient {
       body: JSON.stringify({ query, variables }),
     });
 
-    console.log('GraphQL响应状态:', response.status);
+    console.log('📥 GraphQL响应状态:', response.status);
 
     if (!response.ok) {
       const errorText = await response.text();
-      console.error('GraphQL HTTP错误:', response.status, errorText);
+      console.error('❌ GraphQL HTTP错误:', response.status, errorText);
       throw new Error(`HTTP ${response.status}: ${errorText}`);
     }
 
     const result = await response.json();
-    console.log('GraphQL响应数据:', result);
+    console.log('✅ GraphQL响应数据:', result);
     
     if (result.errors && result.errors.length > 0) {
-      console.error('GraphQL业务错误:', result.errors);
+      console.error('❌ GraphQL业务错误:', result.errors);
       throw new Error(result.errors[0].message || '未知GraphQL错误');
     }
 
@@ -109,35 +174,35 @@ export class GraphQLClient {
 
     for (let attempt = 1; attempt <= this.maxRetries; attempt++) {
       try {
-        console.log(`GraphQL请求尝试 ${attempt}/${this.maxRetries}`);
+        console.log(`🔄 GraphQL请求尝试 ${attempt}/${this.maxRetries}`);
         return await this.executeRequest(query, variables);
       } catch (error) {
         lastError = error as Error;
-        console.warn(`GraphQL请求失败 (尝试 ${attempt}/${this.maxRetries}):`, error);
+        console.warn(`⚠️ GraphQL请求失败 (尝试 ${attempt}/${this.maxRetries}):`, error);
         
         // 如果不是最后一次尝试，等待后重试
         if (attempt < this.maxRetries) {
           const delayMs = this.retryDelay * attempt;
-          console.log(`等待 ${delayMs}ms 后重试`);
+          console.log(`⏳ 等待 ${delayMs}ms 后重试`);
           await this.delay(delayMs);
         }
       }
     }
 
-    console.error('GraphQL请求最终失败:', lastError);
+    console.error('💥 GraphQL请求最终失败:', lastError);
     throw lastError || new Error('GraphQL请求失败');
   }
 
   // 测试连接
   async testConnection(): Promise<boolean> {
     try {
-      console.log('测试GraphQL连接...');
+      console.log('🔍 测试GraphQL连接...');
       const data = await this.request<{ hello: string }>(HELLO_QUERY);
       const isConnected = data.hello === 'Hello from GraphQL API!';
-      console.log('GraphQL连接测试结果:', isConnected, data);
+      console.log('🎯 GraphQL连接测试结果:', isConnected ? '✅ 成功' : '❌ 失败', data);
       return isConnected;
     } catch (error) {
-      console.error('GraphQL连接测试失败:', error);
+      console.error('❌ GraphQL连接测试失败:', error);
       return false;
     }
   }
@@ -155,7 +220,7 @@ export class GraphQLClient {
       }
     });
 
-    console.log('发送聊天消息:', messages);
+    console.log('💬 发送聊天消息:', messages);
 
     try {
       const data = await this.request<{ chat: ChatResponse }>(
@@ -163,18 +228,40 @@ export class GraphQLClient {
         { input: { messages } }
       );
       
-      console.log('聊天响应:', data);
+      console.log('🎉 聊天响应成功:', data);
       return data.chat;
     } catch (error) {
-      console.error('发送聊天消息失败:', error);
+      console.error('❌ 发送聊天消息失败:', error);
       throw error;
     }
+  }
+
+  // 使用REST API作为备用方案
+  async sendChatMessageRest(messages: Message[]): Promise<ChatResponse> {
+    console.log('🔄 使用REST API备用方案:', this.restEndpoint);
+    
+    const response = await fetch(this.restEndpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ messages }),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`REST API错误: ${response.status} - ${errorText}`);
+    }
+
+    const data = await response.json();
+    console.log('✅ REST API响应:', data);
+    return data;
   }
 
   // 获取当前状态信息
   getStatus() {
     return {
       endpoint: this.endpoint,
+      healthEndpoint: this.healthEndpoint,
+      restEndpoint: this.restEndpoint,
       maxRetries: this.maxRetries,
       retryDelay: this.retryDelay,
     };
@@ -184,7 +271,7 @@ export class GraphQLClient {
   updateConfig(config: { endpoint?: string; maxRetries?: number; retryDelay?: number }) {
     if (config.endpoint) {
       this.endpoint = config.endpoint;
-      console.log('GraphQL端点已更新:', this.endpoint);
+      console.log('🔧 GraphQL端点已更新:', this.endpoint);
     }
     if (config.maxRetries) this.maxRetries = config.maxRetries;
     if (config.retryDelay) this.retryDelay = config.retryDelay;
@@ -201,17 +288,26 @@ export const sendChatMessage = (messages: Message[]) =>
 export const testGraphQLConnection = () => 
   graphqlClient.testConnection();
 
+// 修复健康检查函数，使用正确的Worker端点
 export const getHealthStatus = async (): Promise<boolean> => {
   try {
-    const response = await fetch('/api/health');
-    return response.ok;
-  } catch {
+    const healthUrl = getHealthUrl();
+    console.log('🏥 检查健康状态:', healthUrl);
+    
+    const response = await fetch(healthUrl);
+    const isHealthy = response.ok;
+    
+    console.log('🏥 健康检查结果:', isHealthy ? '✅ 正常' : '❌ 异常');
+    return isHealthy;
+  } catch (error) {
+    console.error('❌ 健康检查失败:', error);
     return false;
   }
 };
 
 export const refreshGraphQLConnection = async (): Promise<boolean> => {
   try {
+    console.log('🔄 刷新GraphQL连接...');
     // 重新创建客户端实例
     const newClient = new GraphQLClient();
     const isConnected = await newClient.testConnection();
@@ -219,13 +315,23 @@ export const refreshGraphQLConnection = async (): Promise<boolean> => {
       // 更新全局客户端的配置
       graphqlClient.updateConfig({ endpoint: newClient.getStatus().endpoint });
     }
+    console.log('🔄 连接刷新结果:', isConnected ? '✅ 成功' : '❌ 失败');
     return isConnected;
-  } catch {
+  } catch (error) {
+    console.error('❌ 刷新连接失败:', error);
     return false;
   }
 };
 
 export const getGraphQLStatus = () => graphqlClient.getStatus();
 
+// 导出REST备用方案
+export const sendChatMessageRest = (messages: Message[]) => 
+  graphqlClient.sendChatMessageRest(messages);
+
 // 调试信息
-console.log('GraphQL客户端模块已加载，默认端点:', getApiUrl());
+console.log('🎯 GraphQL客户端模块已加载');
+console.log('📍 默认端点配置:');
+console.log('  - GraphQL:', getApiUrl());
+console.log('  - Health:', getHealthUrl());
+console.log('  - REST:', getRestUrl());


### PR DESCRIPTION
## 🎯 强制使用 GraphQL 并修复端点配置

此 PR 解决了 GraphQL 调用问题，确保应用优先使用 GraphQL 而不是 REST API。

### 🐛 问题分析

原来的代码存在以下问题：
1. **错误的端点配置** - `getHealthStatus()` 使用相对路径 `/api/health`，无法正确访问 Worker
2. **不完整的REST备用方案** - REST API 调用也使用相对路径，导致失败后无法正确回退
3. **调试信息不足** - 难以追踪是否真正使用了 GraphQL

### ✅ 修复内容

1. **修复端点配置**
   - ✅ 所有API调用现在使用完整的Worker端点
   - ✅ GraphQL: `https://ai-chat-api.593496637.workers.dev/api/graphql`
   - ✅ Health: `https://ai-chat-api.593496637.workers.dev/api/health`
   - ✅ REST: `https://ai-chat-api.593496637.workers.dev/api/chat`

2. **增强GraphQL优先级**
   - ✅ 默认强制启用 GraphQL (`useGraphQL: true`)
   - ✅ 每次都优先尝试 GraphQL
   - ✅ 只有 GraphQL 失败时才使用 REST 备用方案
   - ✅ 下次发送消息仍会优先尝试 GraphQL

3. **添加详细调试信息**
   - ✅ 丰富的控制台日志，使用 emoji 图标便于识别
   - ✅ 显示每个请求使用的端点
   - ✅ 标明是否成功使用 GraphQL
   - ✅ 详细的错误信息和重试过程

4. **改进错误处理**
   - ✅ GraphQL 失败时自动使用 REST 备用方案
   - ✅ 保持重试机制（3次重试）
   - ✅ 更好的错误消息展示

### 📊 现在的工作流程

```
发送消息 → 
  ├── 优先尝试 GraphQL
  │   ├── 成功 ✅ → 显示结果
  │   └── 失败 ❌ → 尝试 REST 备用
  └── REST 备用方案
      ├── 成功 ✅ → 显示结果（下次仍优先 GraphQL）
      └── 失败 ❌ → 显示错误
```

### 🎯 控制台调试信息

现在您会在浏览器控制台看到类似这样的信息：

```
🚀 GraphQL客户端初始化:
  - GraphQL端点: https://ai-chat-api.593496637.workers.dev/api/graphql
  - 健康检查端点: https://ai-chat-api.593496637.workers.dev/api/health
  - REST备用端点: https://ai-chat-api.593496637.workers.dev/api/chat

🚀 开始发送消息，当前配置: { useGraphQL: true, messageCount: 1 }
📡 尝试使用GraphQL发送消息...
📤 发送GraphQL请求: { query: "mutation chat...", variables: {...} }
📥 GraphQL响应状态: 200
✅ GraphQL响应数据: { data: { chat: {...} } }
✅ GraphQL消息发送成功
🎉 消息发送完成 { usedGraphQL: true, responseLength: 145 }
```

### 🔧 环境支持

支持多种部署环境：
- **Pages 预览**: 自动使用 Worker 端点
- **生产环境**: 支持 bestvip.life 域名
- **本地开发**: 支持 localhost:8787

### 📈 预期结果

- ✅ 每次发送消息都优先使用 GraphQL
- ✅ 控制台显示详细的调试信息
- ✅ GraphQL 失败时自动回退到 REST
- ✅ 连接检查使用正确的 Worker 端点
- ✅ 完全消除相对路径导致的 404 错误

这次修复确保您的应用真正使用 GraphQL 与 DeepSeek AI 进行交互！
